### PR TITLE
Link and copy updates - Mar 2023

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -24,8 +24,8 @@ ListItem.defaultProps = {
 
 const links = [
   {
-    title: 'CodePen',
-    href: 'https://codepen.io/ajosedev',
+    title: 'Garden',
+    href: 'https://garden.ajose.dev',
   },
   {
     title: 'GitHub',
@@ -36,11 +36,8 @@ const links = [
     href: 'https://www.linkedin.com/in/ajosedev',
   },
   {
-    title: 'TIL',
-    to: '/til',
-    // }, {
-    //   title: 'Labs',
-    //   to: '/labs',
+    title: 'CodePen',
+    href: 'https://codepen.io/ajosedev',
   },
 ];
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -54,7 +54,7 @@ const Index = () => (
       </div>
     </header>
     <div className="fluid-type" css={styles.role}>
-      <p>Full Stack</p>
+      <p>Software</p>
       <p>Engineer</p>
     </div>
     <nav css={styles.nav}>


### PR DESCRIPTION
Just some small tweaks to the copy and links on the home page.

I want to do a full redesign in the future, but until then, this will do.

I've removed the `/til` link, but the code is still there.